### PR TITLE
updates to access.html: proxies and launch/patient

### DIFF
--- a/input/pagecontent/access.md
+++ b/input/pagecontent/access.md
@@ -38,7 +38,7 @@ Servers that are conformant to the International Patient Access API conform to t
 * The server hosts a [smart-configuration file](http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known) at [url]/.well-known/smart-configuration.json that is available to both authenticated and unauthenticated clients.
 * The server conforms to the [SMART App Launch specification](http://hl7.org/fhir/smart-app-launch/), and checks that the authenticated user of the application has access. 
 * If the client requests access to a patient record, the server checks that the authenticated user of the application has access to the specified record. 
-* If the client does not nominate a particular patient record, the server requires that the user must choose a single patient record to which the application has access.
+* If the user is authorized to access multiple patient records, the server requires that the user must choose a single patient record to which the application has access.
 * The server enforces [patient privacy and consent](privacy.html).
 
 Note that both the CapabilityStatement and the smart configuration file may be different for authenticated and unauthenticated clients.

--- a/input/pagecontent/access.md
+++ b/input/pagecontent/access.md
@@ -39,6 +39,7 @@ Servers that are conformant to the International Patient Access API conform to t
 * The server conforms to the [SMART App Launch specification](http://hl7.org/fhir/smart-app-launch/), and checks that the authenticated user of the application has access. 
 * If the client requests access to a patient record, the server checks that the authenticated user of the application has access to the specified record. 
 * If the user is authorized to access multiple patient records, the server requires that the user must choose a single patient record to which the application has access.
+* The client SHALL request the `launch/patient` scope and the server SHALL return a patient FHIR identifier as a [SMART launch context parameter](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#requesting-context-with-scopes). 
 * The server enforces [patient privacy and consent](privacy.html).
 
 Note that both the CapabilityStatement and the smart configuration file may be different for authenticated and unauthenticated clients.

--- a/input/pagecontent/access.md
+++ b/input/pagecontent/access.md
@@ -39,7 +39,7 @@ Servers that are conformant to the International Patient Access API conform to t
 * The server conforms to the [SMART App Launch specification](http://hl7.org/fhir/smart-app-launch/), and checks that the authenticated user of the application has access. 
 * If the client requests access to a patient record, the server checks that the authenticated user of the application has access to the specified record. 
 * If the user is authorized to access multiple patient records, the server requires that the user must choose a single patient record to which the application has access.
-* The client SHALL request the `launch/patient` scope and the server SHALL return a patient FHIR identifier as a [SMART launch context parameter](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#requesting-context-with-scopes). 
+* The client SHALL request the `launch/patient` scope and the server SHALL return a Patient FHIR resource identifier as the `patient` [SMART launch context parameter](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#requesting-context-with-scopes). 
 * The server enforces [patient privacy and consent](privacy.html).
 
 Note that both the CapabilityStatement and the smart configuration file may be different for authenticated and unauthenticated clients.

--- a/input/pagecontent/access.md
+++ b/input/pagecontent/access.md
@@ -38,7 +38,7 @@ Servers that are conformant to the International Patient Access API conform to t
 * The server hosts a [smart-configuration file](http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known) at [url]/.well-known/smart-configuration.json that is available to both authenticated and unauthenticated clients.
 * The server conforms to the [SMART App Launch specification](http://hl7.org/fhir/smart-app-launch/), and checks that the authenticated user of the application has access. 
 * If the client requests access to a patient record, the server checks that the authenticated user of the application has access to the specified record. 
-* If the user is authorized to access multiple patient records, the server requires that the user must choose a single patient record to which the application has access.
+* If the user is authorized to access multiple patient records, the server typically requires that the user choose a single patient record to which the application has access.
 * The client SHALL request the `launch/patient` scope and the server SHALL return a Patient FHIR resource identifier as the `patient` [SMART launch context parameter](http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#requesting-context-with-scopes). 
 * The server enforces [patient privacy and consent](privacy.html).
 


### PR DESCRIPTION
I'm pretty sure that a smart app doesn't have the capability of asking that a specific patient be selected before/during launch, only that the OAuth server present the patient chooser with the `launch/patient` scope ... and `launch/patient` / a patient chooser only makes sense when the user has access to multiple patients.