### PR TITLE
Change Immunization to DocumentReference

### DIFF
--- a/input/pagecontent/StructureDefinition-ipa-documentreference-intro.md
+++ b/input/pagecontent/StructureDefinition-ipa-documentreference-intro.md
@@ -6,7 +6,7 @@
 The following data elements must always be present (in other words, mandatory resource properties where the minimum cardinality is 1) or must be supported ([Must Support](conformance.html#must-support) definition). Servers cannot restrict access to mandatory elements when authorizing an application. However, servers may choose to provide additional information or may be required to do so by national or other profiles that apply to the server's context.
 
 
-**Each Immunization SHALL have:**
+**Each DocumentReference SHALL have:**
 * a status
 * a patient
 * one or more documents referenced (content) which is either a URL where the data can be found or inline data or both


### PR DESCRIPTION
Fixed a typo in the DocumentReference intro that referenced Immunization instead of DocumentReference