### PR TITLE
Remove UCUM system from cigarette pack-years

### DIFF
--- a/input/examples/Observation-SmokingExample1.json
+++ b/input/examples/Observation-SmokingExample1.json
@@ -116,9 +116,7 @@
       },
       "valueQuantity": {
         "value": 3.72,
-        "unit": "{PackYears}",
-        "system": "http://unitsofmeasure.org",
-        "code": "{PackYears}"
+        "unit": "pack-years"
       }
     },
     {

--- a/input/examples/Observation-SmokingExample1.json
+++ b/input/examples/Observation-SmokingExample1.json
@@ -116,7 +116,9 @@
       },
       "valueQuantity": {
         "value": 3.72,
-        "unit": "pack-years"
+        "unit": "{pack-years}",
+        "system": "http://unitsofmeasure.org",
+        "code": "1"
       }
     },
     {


### PR DESCRIPTION
At least the latest version of UCUM seems not to include this code. See [UCUM common units](https://ucum.org/docs/common-units):

> We excluded the units of measure for which we couldn’t find clear definitions or patterns of usage, those we believed would only be used in pharmacy dispensing, and units used for purely clinical reporting (e.g. **cigarette pack-years**).

It is unclear whether the code was ever a UCUM code and if it was, how exactly it was spelled.

I did notice that [US Core profile](https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-smokingstatus.html) requires UCUM units to be used. However, the example provided with that profile has this same problem with the latest QA checker.